### PR TITLE
add support for compiled electron apps

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -116,7 +116,7 @@ _diskSpace = function(async, callback, phSystem, phOutput) {
       }
     } else {
       if (!phOutput) {
-        stdout = child_process.execSync('wmic logicaldisk get size,freespace,caption').toString();
+        stdout = child_process.execSync('wmic logicaldisk get size,freespace,caption', {stdio: 'pipe'}).toString();
       } else {
         stdout = phOutput;
       }

--- a/bin/index.js
+++ b/bin/index.js
@@ -136,7 +136,7 @@ _diskSpace = function(async, callback, phSystem, phOutput) {
       }
     } else {
       if (!phOutput) {
-        stdout = child_process.execSync('df').toString();
+        stdout = child_process.execSync('df', {stdio: 'pipe'}).toString();
       } else {
         stdout = phOutput;
       }


### PR DESCRIPTION
Compiled electron apps on windows (exe) are working without any stdout. Only console.log is available. The result was `Uncaught Error: EPERM: operation not permitted, write`

https://github.com/Storj/storjshare-gui/issues/227#issuecomment-224851133

This pull request fix this problem and makes fd-diskspace electron compatible.

Please merge and release it.